### PR TITLE
feat(hand-class): created PokerHand.kt and PokerHandTest.kt with full line coverage.

### DIFF
--- a/src/main/kotlin/hwr/oop/projects/peakpoker/core/hand/HandEvaluator.kt
+++ b/src/main/kotlin/hwr/oop/projects/peakpoker/core/hand/HandEvaluator.kt
@@ -4,16 +4,20 @@ import hwr.oop.projects.peakpoker.core.card.Card
 import hwr.oop.projects.peakpoker.core.card.CommunityCards
 import hwr.oop.projects.peakpoker.core.card.HoleCards
 
-object HandEvaluator {
 
 
+/**
+ * Evaluates poker hands and determines winning players.
+ * Replaces the singleton implementation with a class-based approach.
+ */
+class HandEvaluator {
     /**
      * Determines the player with the highest hand among a list of players.
      *
-     * @param holeCardsList A list of `HoleCards` representing each player's cards.
-     * @param community The `CommunityCards` shared by all players.
-     * @return The `HoleCards` of the player with the highest hand.
-     * @throws IllegalArgumentException If the list of players is empty.
+     * @param holeCardsList A list of [HoleCards] representing each player's cards
+     * @param community The [CommunityCards] shared by all players
+     * @return The [HoleCards] of the player with the highest hand
+     * @throws IllegalArgumentException If the list of players is empty
      */
     fun determineHighestHand(holeCardsList: List<HoleCards>, community: CommunityCards): HoleCards {
         require(holeCardsList.isNotEmpty()) { "Must provide at least one player" }
@@ -23,7 +27,7 @@ object HandEvaluator {
 
         for (player in holeCardsList.drop(1)) {
             val currentHand = getBestCombo(player, community)
-            if (compareHands(currentHand, bestHand) > 0) {
+            if (currentHand.compareTo(bestHand) > 0) {
                 bestHand = currentHand
                 bestPlayerHand = player
             }
@@ -32,115 +36,37 @@ object HandEvaluator {
     }
 
     /**
-     * Evaluates the rank of a given hand of cards.
+     * Finds the best 5-card poker hand from a player's hole cards and the community cards.
      *
-     * @param cards A list of `Card` objects representing the hand to evaluate.
-     * @return The `HandRank` of the evaluated hand.
-     * @throws IllegalArgumentException If the hand does not contain exactly 5 unique cards.
+     * @param hole The [HoleCards] of the player
+     * @param community The [CommunityCards] shared by all players
+     * @return The best [PokerHand] combination
+     * @throws IllegalArgumentException If the total number of cards is not 7
+     * @throws IllegalStateException If no valid hand could be found
      */
-    private fun evaluate(cards: List<Card>): HandRank {
-        require(cards.size == 5) { "Hand must contain exactly 5 cards" }
-        require(cards.distinct().size == 5) { "Hand must contain 5 unique cards" }
-
-        val ranks = cards.map { it.rank }
-        val suits = cards.map { it.suit }
-        val rankCounts =
-            ranks.groupingBy { it }.eachCount().values.sortedDescending()
-        val isFlush = suits.distinct().size == 1
-
-        val values = ranks
-            .sortedBy { it.value }
-            .map { it.value }
-        val isWheel = values == listOf(1, 2, 3, 4, 13)
-        val isSequential = values.zipWithNext().all { (a, b) -> b == a + 1 }
-        val isStraight = isWheel || isSequential
-        val isRoyal = values == listOf(9, 10, 11, 12, 13)
-
-        return when {
-            isRoyal && isFlush                          -> HandRank.ROYAL_FLUSH
-            isStraight && isFlush                       -> HandRank.STRAIGHT_FLUSH
-            rankCounts[0] == 4                          -> HandRank.FOUR_OF_A_KIND
-            rankCounts[0] == 3 && rankCounts[1] == 2    -> HandRank.FULL_HOUSE
-            isFlush                                     -> HandRank.FLUSH
-            isStraight                                  -> HandRank.STRAIGHT
-            rankCounts[0] == 3                          -> HandRank.THREE_OF_A_KIND
-            rankCounts[0] == 2 && rankCounts[1] == 2    -> HandRank.TWO_PAIR
-            rankCounts[0] == 2                          -> HandRank.ONE_PAIR
-            else                                        -> HandRank.HIGH_CARD
-        }
-    }
-
-    /**
-     * Compares two hands of cards to determine which is stronger.
-     *
-     * @param hand1 A list of `Card` objects representing the first hand.
-     * @param hand2 A list of `Card` objects representing the second hand.
-     * @return An integer: positive if `h1` is stronger, negative if `h2` is stronger, or zero if they are equal.
-     */
-   private fun compareHands(hand1: List<Card>, hand2: List<Card>): Int {
-        val rank1 = evaluate(hand1)
-        val rank2 = evaluate(hand2)
-
-        if (rank1 != rank2) {
-            return rank1.rank.compareTo(rank2.rank)
-        }
-
-        val v1 = hand1.map { it.rank.value }.sortedDescending()
-        val v2 = hand2.map { it.rank.value }.sortedDescending()
-
-        for (i in v1.indices) {
-            val cmp = v1[i].compareTo(v2[i])
-            if (cmp != 0) return cmp
-        }
-
-        return 0
-    }
-
-
-    /**
-     * Finds the best combination of 5 cards from a player's hole cards and the community cards.
-     *
-     * @param hole The `HoleCards` of the player.
-     * @param community The `CommunityCards` shared by all players.
-     * @return A list of `Card` objects representing the best combination of 5 cards.
-     * @throws IllegalArgumentException If the total number of cards is not 7.
-     */
-    private fun getBestCombo(hole: HoleCards, community: CommunityCards): List<Card> {
+    private fun getBestCombo(hole: HoleCards, community: CommunityCards): PokerHand {
         val allCards = hole.cards + community.cards
         require(allCards.size == 7) { "Total cards must be 7 (2 hole + 5 community)" }
 
-        var bestCombo: List<Card> = emptyList()
-        var bestRank = HandRank.HIGH_CARD
+        var bestCombo: PokerHand? = null
         val cardCount = 7
         val totalMasks = 1 shl cardCount
 
         for (mask in 0 until totalMasks) {
-            if (Integer.bitCount(mask) != 5) {
-                continue
-            }
+            if (Integer.bitCount(mask) != 5) continue
 
             val combo = mutableListOf<Card>()
             for (i in 0 until cardCount) {
                 if ((mask shr i) and 1 == 1) combo.add(allCards[i])
             }
 
-            val handRank = evaluate(combo)
-
-            if (handRank.rank > bestRank.rank) {
-                bestRank = handRank
-                bestCombo = combo
-                continue
-            }
-
-            if (handRank.rank == bestRank.rank) {
-                if (bestCombo.isEmpty() || compareHands(combo, bestCombo) > 0) {
-                    bestCombo = combo
-                    continue
-                }
+            val hand = PokerHand(combo)
+            if (bestCombo == null || hand.compareTo(bestCombo) > 0) {
+                bestCombo = hand
             }
         }
 
-        return bestCombo
+        return bestCombo ?: throw IllegalStateException("No valid hand found")
     }
 }
 

--- a/src/main/kotlin/hwr/oop/projects/peakpoker/core/hand/PokerHand.kt
+++ b/src/main/kotlin/hwr/oop/projects/peakpoker/core/hand/PokerHand.kt
@@ -1,0 +1,76 @@
+package hwr.oop.projects.peakpoker.core.hand
+
+import hwr.oop.projects.peakpoker.core.card.Card
+
+/**
+ * Represents a poker hand consisting of exactly 5 cards.
+ * Provides functionality to evaluate and compare poker hands.
+ *
+ * @property cards The list of cards that make up the hand
+ */
+class PokerHand(private val cards: List<Card>) {
+    init {
+        require(cards.size == 5) { "Hand must contain exactly 5 cards" }
+        require(cards.distinct().size == 5) { "Hand must contain 5 unique cards" }
+    }
+
+    val rank: HandRank by lazy { evaluate() }
+
+    /**
+     * Evaluates the rank of this poker hand.
+     *
+     * @return The [HandRank] of the evaluated hand
+     * @throws IllegalStateException if the hand doesn't meet validation criteria
+     */
+    private fun evaluate(): HandRank {
+        // Dieselbe Logik wie vorher
+        val ranks = cards.map { it.rank }
+        val suits = cards.map { it.suit }
+        val rankCounts = ranks.groupingBy { it }.eachCount().values.sortedDescending()
+        val isFlush = suits.distinct().size == 1
+
+        val values = ranks
+            .sortedBy { it.value }
+            .map { it.value }
+        val isWheel = values == listOf(1, 2, 3, 4, 13)
+        val isSequential = values.zipWithNext().all { (a, b) -> b == a + 1 }
+        val isStraight = isWheel || isSequential
+        val isRoyal = values == listOf(9, 10, 11, 12, 13)
+
+        return when {
+            isRoyal && isFlush                          -> HandRank.ROYAL_FLUSH
+            isStraight && isFlush                       -> HandRank.STRAIGHT_FLUSH
+            rankCounts[0] == 4                          -> HandRank.FOUR_OF_A_KIND
+            rankCounts[0] == 3 && rankCounts[1] == 2    -> HandRank.FULL_HOUSE
+            isFlush                                     -> HandRank.FLUSH
+            isStraight                                  -> HandRank.STRAIGHT
+            rankCounts[0] == 3                          -> HandRank.THREE_OF_A_KIND
+            rankCounts[0] == 2 && rankCounts[1] == 2    -> HandRank.TWO_PAIR
+            rankCounts[0] == 2                          -> HandRank.ONE_PAIR
+            else                                        -> HandRank.HIGH_CARD
+        }
+    }
+
+    /**
+     * Compares this poker hand to another poker hand to determine which is stronger.
+     *
+     * @param other The other poker hand to compare against
+     * @return A positive integer if this hand is stronger, negative if the other hand is stronger,
+     *         or zero if they are equal
+     */
+    fun compareTo(other: PokerHand): Int {
+        if (rank != other.rank) {
+            return rank.rank.compareTo(other.rank.rank)
+        }
+
+        val v1 = cards.map { it.rank.value }.sortedDescending()
+        val v2 = other.cards.map { it.rank.value }.sortedDescending()
+
+        for (i in v1.indices) {
+            val cmp = v1[i].compareTo(v2[i])
+            if (cmp != 0) return cmp
+        }
+
+        return 0
+    }
+}

--- a/src/test/kotlin/hwr/oop/projects/peakpoker/core/hand/HandEvaluatorTest.kt
+++ b/src/test/kotlin/hwr/oop/projects/peakpoker/core/hand/HandEvaluatorTest.kt
@@ -27,19 +27,23 @@ import hwr.oop.projects.peakpoker.core.player.PlayerInterface
 import org.assertj.core.api.Assertions.assertThat
 
 class HandEvaluatorTest : AnnotationSpec() {
+  private val evaluator = HandEvaluator()
+
   private val mockPlayer = object : PlayerInterface {
     override val name: String = "dummy"
+    @Suppress("unused")
     val id: String = "dummyId"
   }
 
   private val mockGame = object : GameInterface {
     override val id: GameId = GameId("dummyGameId")
   }
-  //SECTION: HandEvaluator.determineHighestHand
+
   /**
    * Verifies that a single player wins by default when no competition exists.
    */
   @Test
+
   fun `single player wins by default`() {
     val holeCards = HoleCards(
       listOf(
@@ -58,12 +62,12 @@ class HandEvaluatorTest : AnnotationSpec() {
       ), mockGame
     )
 
-    val winner = HandEvaluator.determineHighestHand(listOf(holeCards), community)
+    val winner = evaluator.determineHighestHand(listOf(holeCards), community)
     assertThat(winner.player).isEqualTo(mockPlayer)
   }
 
   /**
-   * Verifies that a single player wins by default when no competition exists.
+   * Ensures that a higher pair beats a lower pair between two players.
    */
   @Test
   fun `higher pair wins between two players`() {
@@ -73,20 +77,21 @@ class HandEvaluatorTest : AnnotationSpec() {
     }
     val player2 = object : PlayerInterface {
       override val name = "Bob"
+      @Suppress("unused")
       val id = "2"
     }
 
     // Alice has pair of Aces
     val hole1 = HoleCards(
       listOf(Card(HEARTS, ACE),
-                    Card(SPADES, ACE)),
+        Card(SPADES, ACE)),
       player1
     )
 
     // Bob has pair of Kings
     val hole2 = HoleCards(
       listOf(Card(DIAMONDS, KING),
-                    Card(CLUBS, KING)),
+        Card(CLUBS, KING)),
       player2
     )
 
@@ -100,7 +105,7 @@ class HandEvaluatorTest : AnnotationSpec() {
       ), mockGame
     )
 
-    val winner = HandEvaluator.determineHighestHand(listOf(hole1, hole2), community)
+    val winner = evaluator.determineHighestHand(listOf(hole1, hole2), community)
     assertThat(winner.player.name).isEqualTo("Alice")
   }
 
@@ -111,24 +116,26 @@ class HandEvaluatorTest : AnnotationSpec() {
   fun `straight beats pair`() {
     val straightPlayer = object : PlayerInterface {
       override val name = "Straight"
+      @Suppress("unused")
       val id = "1"
     }
     val pairPlayer = object : PlayerInterface {
       override val name = "Pair"
+      @Suppress("unused")
       val id = "2"
     }
 
     // Player can make straight (3-7)
     val holeStraight = HoleCards(
       listOf(Card(HEARTS, THREE),
-                    Card(SPADES, SEVEN)),
+        Card(SPADES, SEVEN)),
       straightPlayer
     )
 
     // Player has pair
     val holePair = HoleCards(
       listOf(Card(DIAMONDS, ACE),
-                    Card(CLUBS, ACE)),
+        Card(CLUBS, ACE)),
       pairPlayer
     )
 
@@ -142,7 +149,7 @@ class HandEvaluatorTest : AnnotationSpec() {
       ), mockGame
     )
 
-    val winner = HandEvaluator.determineHighestHand(
+    val winner = evaluator.determineHighestHand(
       listOf(holeStraight, holePair), community
     )
     assertThat(winner.player.name).isEqualTo("Straight")
@@ -165,13 +172,13 @@ class HandEvaluatorTest : AnnotationSpec() {
     // Both have same hand (Ace-high)
     val hole1 = HoleCards(
       listOf(Card(HEARTS, ACE),
-                    Card(SPADES, TWO)),
+        Card(SPADES, TWO)),
       player1
     )
 
     val hole2 = HoleCards(
       listOf(Card(DIAMONDS, ACE),
-                    Card(CLUBS, THREE)),
+        Card(CLUBS, THREE)),
       player2
     )
 
@@ -185,7 +192,7 @@ class HandEvaluatorTest : AnnotationSpec() {
       ), mockGame
     )
 
-    val winner = HandEvaluator.determineHighestHand(
+    val winner = evaluator.determineHighestHand(
       listOf(hole1, hole2), community
     )
     assertThat(winner.player.name).isEqualTo("First")
@@ -208,14 +215,14 @@ class HandEvaluatorTest : AnnotationSpec() {
     // Flush player has two hearts
     val holeFlush = HoleCards(
       listOf(Card(HEARTS, TEN),
-                    Card(HEARTS, JACK)),
+        Card(HEARTS, JACK)),
       flushPlayer
     )
 
     // Straight player
     val holeStraight = HoleCards(
       listOf(Card(CLUBS, NINE),
-                    Card(DIAMONDS, EIGHT)),
+        Card(DIAMONDS, EIGHT)),
       straightPlayer
     )
 
@@ -229,7 +236,7 @@ class HandEvaluatorTest : AnnotationSpec() {
       ), mockGame
     )
 
-    val winner = HandEvaluator.determineHighestHand(
+    val winner = evaluator.determineHighestHand(
       listOf(holeFlush, holeStraight), community
     )
     assertThat(winner.player.name).isEqualTo("Flush")
@@ -252,14 +259,14 @@ class HandEvaluatorTest : AnnotationSpec() {
     // Royal flush player
     val holeRoyal = HoleCards(
       listOf(Card(SPADES, ACE),
-                    Card(SPADES, KING)),
+        Card(SPADES, KING)),
       royalPlayer
     )
 
     // Straight flush player (7-high)
     val holeStraightFlush = HoleCards(
       listOf(Card(HEARTS, SIX),
-                    Card(HEARTS, SEVEN)),
+        Card(HEARTS, SEVEN)),
       straightFlushPlayer
     )
 
@@ -273,7 +280,7 @@ class HandEvaluatorTest : AnnotationSpec() {
       ), mockGame
     )
 
-    val winner = HandEvaluator.determineHighestHand(
+    val winner = evaluator.determineHighestHand(
       listOf(holeRoyal, holeStraightFlush), community
     )
     assertThat(winner.player.name).isEqualTo("Royal")
@@ -294,7 +301,7 @@ class HandEvaluatorTest : AnnotationSpec() {
       ), mockGame
     )
 
-    HandEvaluator.determineHighestHand(emptyList(), community)
+    evaluator.determineHighestHand(emptyList<HoleCards>(), community)
   }
 
   /**
@@ -322,7 +329,7 @@ class HandEvaluatorTest : AnnotationSpec() {
     // Flush player has two hearts
     val holeFlush = HoleCards(
       listOf(Card(HEARTS, TEN),
-                    Card(HEARTS, JACK)),
+        Card(HEARTS, JACK)),
       flushPlayer
     )
 
@@ -335,14 +342,14 @@ class HandEvaluatorTest : AnnotationSpec() {
     // Pair player
     val holePair = HoleCards(
       listOf(Card(CLUBS, TWO),
-                    Card(DIAMONDS, TWO)),
+        Card(DIAMONDS, TWO)),
       pairPlayer
     )
 
     // High card player
     val holeHighCard = HoleCards(
       listOf(Card(SPADES, THREE),
-                    Card(CLUBS, FOUR)),
+        Card(CLUBS, FOUR)),
       highCardPlayer
     )
 
@@ -356,9 +363,308 @@ class HandEvaluatorTest : AnnotationSpec() {
       ), mockGame
     )
 
-    val winner = HandEvaluator.determineHighestHand(
-      listOf(holeFlush, holeStraight), community
+    val winner = evaluator.determineHighestHand(
+      listOf(holeFlush, holeStraight, holePair, holeHighCard), community
     )
     assertThat(winner.player.name).isEqualTo("Flush")
+  }
+  /**
+   * Tests that an exception is thrown when the total number of cards isn't 7.
+   */
+  @Test(expected = IllegalArgumentException::class)
+  fun `throws exception when total cards is not 7`() {
+    // Use valid CommunityCards but with duplicate cards in HoleCards to create an invalid combination
+    val duplicateCard = Card(CLUBS, ACE)
+
+    val community = CommunityCards(
+      listOf(
+        duplicateCard,
+        Card(DIAMONDS, KING),
+        Card(HEARTS, QUEEN),
+        Card(SPADES, JACK),
+        Card(CLUBS, TEN)
+      ), mockGame
+    )
+
+    val holeCards = HoleCards(
+      listOf(
+        duplicateCard, // Same card as in community
+        Card(DIAMONDS, THREE)
+      ), mockPlayer
+    )
+
+    // This should throw an IllegalArgumentException in getBestCombo when it checks the combined card count
+    evaluator.determineHighestHand(listOf(holeCards), community)
+  }
+
+  /**
+   * Test to ensure the bit manipulation logic works correctly with edge case patterns.
+   * This specifically targets code coverage in the getBestCombo method.
+   */
+  @Test
+  fun `selects best hand when all combinations are considered`() {
+    // Create a player with a potential royal flush in spades
+    val royalPlayer = object : PlayerInterface {
+      override val name = "Royal"
+    }
+
+    // Give exactly the cards needed for a royal flush
+    val holeRoyal = HoleCards(
+      listOf(
+        Card(SPADES, ACE),
+        Card(SPADES, KING)
+      ), royalPlayer
+    )
+
+    val community = CommunityCards(
+      listOf(
+        Card(SPADES, QUEEN),
+        Card(SPADES, JACK),
+        Card(SPADES, TEN),
+        // Add cards that would create tempting but inferior hands
+        Card(HEARTS, ACE),
+        Card(DIAMONDS, ACE)
+      ), mockGame
+    )
+
+    val winner = evaluator.determineHighestHand(listOf(holeRoyal), community)
+
+    // The player should have a royal flush, which is the best possible hand
+    assertThat(winner.player.name).isEqualTo("Royal")
+  }
+
+  /**
+   * Test to ensure the early return logic is covered when the first player
+   * is the only player.
+   */
+  @Test
+  fun `first player is best when they are the only player`() {
+    val player = object : PlayerInterface {
+      override val name = "OnlyPlayer"
+    }
+
+    val holeCards = HoleCards(
+      listOf(
+        Card(HEARTS, TWO),
+        Card(DIAMONDS, THREE)
+      ), player
+    )
+
+    val community = CommunityCards(
+      listOf(
+        Card(CLUBS, FOUR),
+        Card(SPADES, FIVE),
+        Card(HEARTS, SIX),
+        Card(DIAMONDS, SEVEN),
+        Card(CLUBS, EIGHT)
+      ), mockGame
+    )
+
+    // This should return the player directly from the first branch without comparison
+    val winner = evaluator.determineHighestHand(listOf(holeCards), community)
+    assertThat(winner.player.name).isEqualTo("OnlyPlayer")
+  }
+
+  /**
+   * Tests edge cases in the bit manipulation by testing a specific set of combinations.
+   */
+  @Test
+  fun `exercises different bit patterns for card combinations`() {
+    // Create a scenario where multiple valid 5-card hands can be created
+    // but only one is optimal
+    val player = object : PlayerInterface {
+      override val name = "BitPattern"
+    }
+
+    // These hole cards combined with community cards will create multiple possible hands
+    val holeCards = HoleCards(
+      listOf(
+        Card(CLUBS, ACE),
+        Card(CLUBS, KING)
+      ), player
+    )
+
+    // Create community cards that allow multiple hand types
+    val community = CommunityCards(
+      listOf(
+        Card(CLUBS, QUEEN),
+        Card(CLUBS, JACK),
+        Card(DIAMONDS, TEN),  // Potential royal flush or straight flush break
+        Card(HEARTS, ACE),    // Potential pair of aces
+        Card(SPADES, ACE)     // Potential three of a kind
+      ), mockGame
+    )
+
+    val winner = evaluator.determineHighestHand(listOf(holeCards), community)
+    assertThat(winner.player.name).isEqualTo("BitPattern")
+  }
+
+  /**
+   * Tests another edge case for bit manipulation with specific bit patterns.
+   */
+  @Test
+  fun `tests another bit pattern combination`() {
+    // Create a scenario where the best hand would be at a specific bit pattern
+    val player = object : PlayerInterface {
+      override val name = "BitPattern2"
+    }
+
+    // Create a very specific set of cards where the best hand depends on the exact bit pattern selection
+    val holeCards = HoleCards(
+      listOf(
+        Card(CLUBS, FIVE),
+        Card(DIAMONDS, FIVE)
+      ), player
+    )
+
+    val community = CommunityCards(
+      listOf(
+        Card(HEARTS, FIVE),
+        Card(SPADES, ACE),
+        Card(CLUBS, ACE),
+        Card(DIAMONDS, ACE),
+        Card(HEARTS, KING)
+      ), mockGame
+    )
+
+    // Should find full house: Aces full of fives
+    val winner = evaluator.determineHighestHand(listOf(holeCards), community)
+    assertThat(winner.player.name).isEqualTo("BitPattern2")
+  }
+
+  /**
+   * Tests with cards arranged in a specific order to test edge cases in bit manipulation.
+   */
+  @Test
+  fun `tests specific card ordering for bit manipulation`() {
+    val player = object : PlayerInterface {
+      override val name = "OrderTest"
+    }
+
+    // The order of these cards might affect the bit manipulation
+    val holeCards = HoleCards(
+      listOf(
+        Card(CLUBS, TWO),    // First card
+        Card(CLUBS, THREE)   // Second card
+      ), player
+    )
+
+    val community = CommunityCards(
+      listOf(
+        Card(CLUBS, FOUR),   // Third card
+        Card(CLUBS, FIVE),   // Fourth card
+        Card(CLUBS, SIX),    // Fifth card
+        Card(HEARTS, SEVEN), // Sixth card
+        Card(DIAMONDS, EIGHT) // Seventh card
+      ), mockGame
+    )
+
+    // Should find straight flush
+    val winner = evaluator.determineHighestHand(listOf(holeCards), community)
+    assertThat(winner.player.name).isEqualTo("OrderTest")
+  }
+
+  /**
+   * Tests that the best hand is correctly updated when it's not the first player.
+   */
+  @Test
+  fun `second player wins when having better hand than first`() {
+    val player1 = object : PlayerInterface {
+      override val name = "FirstButWorse"
+    }
+
+    val player2 = object : PlayerInterface {
+      override val name = "SecondButBetter"
+    }
+
+    // First player has just a pair of twos
+    val holePlayer1 = HoleCards(
+      listOf(
+        Card(CLUBS, TWO),
+        Card(DIAMONDS, THREE)
+      ), player1
+    )
+
+    // Second player has a pair of aces
+    val holePlayer2 = HoleCards(
+      listOf(
+        Card(HEARTS, ACE),
+        Card(SPADES, KING)
+      ), player2
+    )
+
+    val community = CommunityCards(
+      listOf(
+        Card(SPADES, ACE),     // Gives player2 a pair of aces
+        Card(DIAMONDS, FIVE),
+        Card(HEARTS, SEVEN),
+        Card(CLUBS, NINE),
+        Card(SPADES, TWO)      // Gives player1 a pair of twos
+      ), mockGame
+    )
+
+    val winner = evaluator.determineHighestHand(listOf(holePlayer1, holePlayer2), community)
+    assertThat(winner.player.name).isEqualTo("SecondButBetter")
+  }
+
+  /**
+   * Tests that the best hand is updated when a player after the first has a better hand.
+   */
+  @Test
+  fun `subsequent player with better hand becomes the winner`() {
+    // Create three players to ensure we're testing the full loop logic
+    val player1 = object : PlayerInterface {
+      override val name = "Player1"
+    }
+
+    val player2 = object : PlayerInterface {
+      override val name = "Player2"
+    }
+
+    val player3 = object : PlayerInterface {
+      override val name = "Player3"
+    }
+
+    // First player has a pair of twos
+    val holePlayer1 = HoleCards(
+      listOf(
+        Card(CLUBS, TWO),
+        Card(DIAMONDS, TWO)
+      ), player1
+    )
+
+    // Second player has a pair of threes (better than player1)
+    val holePlayer2 = HoleCards(
+      listOf(
+        Card(HEARTS, THREE),
+        Card(SPADES, THREE)
+      ), player2
+    )
+
+    // Third player has a pair of kings (best of all)
+    val holePlayer3 = HoleCards(
+      listOf(
+        Card(CLUBS, KING),
+        Card(DIAMONDS, FIVE)
+      ), player3
+    )
+
+    val community = CommunityCards(
+      listOf(
+        Card(HEARTS, KING),
+        Card(SPADES, SEVEN),
+        Card(DIAMONDS, EIGHT),
+        Card(CLUBS, NINE),
+        Card(HEARTS, TEN)
+      ), mockGame
+    )
+
+    val winner = evaluator.determineHighestHand(
+      listOf(holePlayer1, holePlayer2, holePlayer3),
+      community
+    )
+
+    // Player3 should win with a pair of kings
+    assertThat(winner.player.name).isEqualTo("Player3")
   }
 }

--- a/src/test/kotlin/hwr/oop/projects/peakpoker/core/hand/PokerHandTest.kt
+++ b/src/test/kotlin/hwr/oop/projects/peakpoker/core/hand/PokerHandTest.kt
@@ -1,0 +1,323 @@
+package hwr.oop.projects.peakpoker.core.hand
+
+import io.kotest.core.spec.style.AnnotationSpec
+import hwr.oop.projects.peakpoker.core.card.Card
+import hwr.oop.projects.peakpoker.core.card.Rank.*
+import hwr.oop.projects.peakpoker.core.card.Suit.*
+import org.assertj.core.api.Assertions.assertThat
+
+class PokerHandTest : AnnotationSpec() {
+
+    // Constructor tests
+    @Test
+    fun `creates valid poker hand with 5 cards`() {
+        val hand = PokerHand(
+            listOf(
+                Card(HEARTS, ACE),
+                Card(SPADES, KING),
+                Card(DIAMONDS, QUEEN),
+                Card(CLUBS, JACK),
+                Card(HEARTS, TEN)
+            )
+        )
+        assertThat(hand).isNotNull
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `throws exception for less than 5 cards`() {
+        PokerHand(
+            listOf(
+                Card(HEARTS, ACE),
+                Card(SPADES, KING),
+                Card(DIAMONDS, QUEEN),
+                Card(CLUBS, JACK)
+            )
+        )
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `throws exception for more than 5 cards`() {
+        PokerHand(
+            listOf(
+                Card(HEARTS, ACE),
+                Card(SPADES, KING),
+                Card(DIAMONDS, QUEEN),
+                Card(CLUBS, JACK),
+                Card(HEARTS, TEN),
+                Card(SPADES, NINE)
+            )
+        )
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `throws exception for duplicate cards`() {
+        PokerHand(
+            listOf(
+                Card(HEARTS, ACE),
+                Card(HEARTS, ACE), // Duplicate card
+                Card(DIAMONDS, QUEEN),
+                Card(CLUBS, JACK),
+                Card(HEARTS, TEN)
+            )
+        )
+    }
+
+    // Hand rank tests
+    @Test
+    fun `correctly identifies royal flush`() {
+        val royalFlush = PokerHand(
+            listOf(
+                Card(HEARTS, ACE),
+                Card(HEARTS, KING),
+                Card(HEARTS, QUEEN),
+                Card(HEARTS, JACK),
+                Card(HEARTS, TEN)
+            )
+        )
+        assertThat(royalFlush.rank).isEqualTo(HandRank.ROYAL_FLUSH)
+    }
+
+    @Test
+    fun `correctly identifies straight flush`() {
+        val straightFlush = PokerHand(
+            listOf(
+                Card(CLUBS, NINE),
+                Card(CLUBS, EIGHT),
+                Card(CLUBS, SEVEN),
+                Card(CLUBS, SIX),
+                Card(CLUBS, FIVE)
+            )
+        )
+        assertThat(straightFlush.rank).isEqualTo(HandRank.STRAIGHT_FLUSH)
+    }
+
+    @Test
+    fun `correctly identifies four of a kind`() {
+        val fourOfAKind = PokerHand(
+            listOf(
+                Card(HEARTS, JACK),
+                Card(DIAMONDS, JACK),
+                Card(CLUBS, JACK),
+                Card(SPADES, JACK),
+                Card(HEARTS, KING)
+            )
+        )
+        assertThat(fourOfAKind.rank).isEqualTo(HandRank.FOUR_OF_A_KIND)
+    }
+
+    @Test
+    fun `correctly identifies full house`() {
+        val fullHouse = PokerHand(
+            listOf(
+                Card(HEARTS, QUEEN),
+                Card(DIAMONDS, QUEEN),
+                Card(CLUBS, QUEEN),
+                Card(SPADES, TWO),
+                Card(HEARTS, TWO)
+            )
+        )
+        assertThat(fullHouse.rank).isEqualTo(HandRank.FULL_HOUSE)
+    }
+
+    @Test
+    fun `correctly identifies flush`() {
+        val flush = PokerHand(
+            listOf(
+                Card(DIAMONDS, ACE),
+                Card(DIAMONDS, JACK),
+                Card(DIAMONDS, NINE),
+                Card(DIAMONDS, SEVEN),
+                Card(DIAMONDS, THREE)
+            )
+        )
+        assertThat(flush.rank).isEqualTo(HandRank.FLUSH)
+    }
+
+    @Test
+    fun `correctly identifies straight`() {
+        val straight = PokerHand(
+            listOf(
+                Card(HEARTS, EIGHT),
+                Card(DIAMONDS, SEVEN),
+                Card(CLUBS, SIX),
+                Card(SPADES, FIVE),
+                Card(HEARTS, FOUR)
+            )
+        )
+        assertThat(straight.rank).isEqualTo(HandRank.STRAIGHT)
+    }
+
+    @Test
+    fun `correctly identifies wheel straight`() {
+        val wheelStraight = PokerHand(
+            listOf(
+                Card(HEARTS, ACE),
+                Card(DIAMONDS, TWO),
+                Card(CLUBS, THREE),
+                Card(SPADES, FOUR),
+                Card(HEARTS, FIVE)
+            )
+        )
+        assertThat(wheelStraight.rank).isEqualTo(HandRank.STRAIGHT)
+    }
+
+    @Test
+    fun `correctly identifies three of a kind`() {
+        val threeOfAKind = PokerHand(
+            listOf(
+                Card(HEARTS, FOUR),
+                Card(DIAMONDS, FOUR),
+                Card(CLUBS, FOUR),
+                Card(SPADES, JACK),
+                Card(HEARTS, ACE)
+            )
+        )
+        assertThat(threeOfAKind.rank).isEqualTo(HandRank.THREE_OF_A_KIND)
+    }
+
+    @Test
+    fun `correctly identifies two pair`() {
+        val twoPair = PokerHand(
+            listOf(
+                Card(HEARTS, NINE),
+                Card(DIAMONDS, NINE),
+                Card(CLUBS, SEVEN),
+                Card(SPADES, SEVEN),
+                Card(HEARTS, ACE)
+            )
+        )
+        assertThat(twoPair.rank).isEqualTo(HandRank.TWO_PAIR)
+    }
+
+    @Test
+    fun `correctly identifies one pair`() {
+        val onePair = PokerHand(
+            listOf(
+                Card(HEARTS, TEN),
+                Card(DIAMONDS, TEN),
+                Card(CLUBS, KING),
+                Card(SPADES, SEVEN),
+                Card(HEARTS, THREE)
+            )
+        )
+        assertThat(onePair.rank).isEqualTo(HandRank.ONE_PAIR)
+    }
+
+    @Test
+    fun `correctly identifies high card`() {
+        val highCard = PokerHand(
+            listOf(
+                Card(HEARTS, ACE),
+                Card(DIAMONDS, KING),
+                Card(CLUBS, JACK),
+                Card(SPADES, SEVEN),
+                Card(HEARTS, THREE)
+            )
+        )
+        assertThat(highCard.rank).isEqualTo(HandRank.HIGH_CARD)
+    }
+
+    // Comparison tests
+    @Test
+    fun `compares different ranked hands correctly`() {
+        val flush = PokerHand(
+            listOf(
+                Card(DIAMONDS, ACE),
+                Card(DIAMONDS, JACK),
+                Card(DIAMONDS, NINE),
+                Card(DIAMONDS, SEVEN),
+                Card(DIAMONDS, THREE)
+            )
+        )
+
+        val straight = PokerHand(
+            listOf(
+                Card(HEARTS, EIGHT),
+                Card(DIAMONDS, SEVEN),
+                Card(CLUBS, SIX),
+                Card(SPADES, FIVE),
+                Card(HEARTS, FOUR)
+            )
+        )
+
+        assertThat(flush.compareTo(straight)).isGreaterThan(0)
+        assertThat(straight.compareTo(flush)).isLessThan(0)
+    }
+
+    @Test
+    fun `compares same ranked hands with different high cards`() {
+        val pairAce = PokerHand(
+            listOf(
+                Card(HEARTS, ACE),
+                Card(DIAMONDS, ACE),
+                Card(CLUBS, KING),
+                Card(SPADES, QUEEN),
+                Card(HEARTS, JACK)
+            )
+        )
+
+        val pairKing = PokerHand(
+            listOf(
+                Card(HEARTS, KING),
+                Card(DIAMONDS, KING),
+                Card(CLUBS, QUEEN),
+                Card(SPADES, JACK),
+                Card(HEARTS, TEN)
+            )
+        )
+
+        assertThat(pairAce.compareTo(pairKing)).isGreaterThan(0)
+        assertThat(pairKing.compareTo(pairAce)).isLessThan(0)
+    }
+
+    @Test
+    fun `compares same ranked hands with same high card but different kickers`() {
+        val pairAceKingHigh = PokerHand(
+            listOf(
+                Card(HEARTS, ACE),
+                Card(DIAMONDS, ACE),
+                Card(CLUBS, KING),
+                Card(SPADES, QUEEN),
+                Card(HEARTS, JACK)
+            )
+        )
+
+        val pairAceQueenHigh = PokerHand(
+            listOf(
+                Card(HEARTS, ACE),
+                Card(DIAMONDS, ACE),
+                Card(CLUBS, QUEEN),
+                Card(SPADES, JACK),
+                Card(HEARTS, TEN)
+            )
+        )
+
+        assertThat(pairAceKingHigh.compareTo(pairAceQueenHigh)).isGreaterThan(0)
+        assertThat(pairAceQueenHigh.compareTo(pairAceKingHigh)).isLessThan(0)
+    }
+
+    @Test
+    fun `compares identical hands as equal`() {
+        val hand1 = PokerHand(
+            listOf(
+                Card(HEARTS, ACE),
+                Card(DIAMONDS, KING),
+                Card(CLUBS, QUEEN),
+                Card(SPADES, JACK),
+                Card(HEARTS, TEN)
+            )
+        )
+
+        val hand2 = PokerHand(
+            listOf(
+                Card(SPADES, ACE),
+                Card(CLUBS, KING),
+                Card(HEARTS, QUEEN),
+                Card(DIAMONDS, JACK),
+                Card(SPADES, TEN)
+            )
+        )
+
+        assertThat(hand1.compareTo(hand2)).isEqualTo(0)
+    }
+}


### PR DESCRIPTION
As discussed in the last ***consultation***, the goal here is to get rid of the Singleton `HandEvaluator.kt`.
I now split the functionality such that `PokerHand.kt` now gets a  list of 5 cards.
It uses evaluate to get the ***handstrength***.

# Role of the PokerHand Class in the Architecture

The `PokerHand` class serves a crucial role in the architecture despite not being directly used in these tests.

## Internal Representation

`PokerHand` is used internally by `HandEvaluator` to represent and evaluate 5-card combinations. In the private `getBestCombo` method, it creates `PokerHand` objects for each possible 5-card combination from the 7 available cards.

## Encapsulation of Poker Logic

`PokerHand` encapsulates all the logic for:
- Determining hand rank (flush, straight, pair, etc.)
- Comparing hands to find the strongest one
- Handling kickers and tiebreakers

## Separation of Concerns
- `HandEvaluator` focuses on finding the best possible hand for each player
- `PokerHand` focuses on evaluating and comparing individual hands

While the tests focus on the public API (`determineHighestHand`), the actual heavy lifting of poker hand valuation happens in the `PokerHand` class. The tests for `PokerHand` itself (in `PokerHandTest.kt`) verify that this core logic works correctly.

This design follows good object-oriented principles by separating:
- Game mechanics (evaluating hands across players)
- Domain objects (the poker hands themselves)

