### PR TITLE
feat: add Dokka Maven plugin for documentation generation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -234,6 +234,19 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.jetbrains.dokka</groupId>
+                <artifactId>dokka-maven-plugin</artifactId>
+                <version>2.0.0</version>
+                <executions>
+                    <execution>
+                        <phase>pre-site</phase>
+                        <goals>
+                            <goal>dokka</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
This PR just adds the Dokka plugin to the `pom.xml` file. From now on we can use it via the Maven plugin section.